### PR TITLE
Removed "-make:transitive" from scalac command line

### DIFF
--- a/scala.project/src/main/resources/org/netbeans/modules/scala/project/resources/build-impl.xsl
+++ b/scala.project/src/main/resources/org/netbeans/modules/scala/project/resources/build-impl.xsl
@@ -522,7 +522,7 @@ is divided into following sections:
                             <xsl:attribute name="excludes">@{excludes}</xsl:attribute>
                             <xsl:attribute name="force">yes</xsl:attribute>
                             <xsl:attribute name="fork">true</xsl:attribute>
-                            <xsl:attribute name="addparams">-make:transitive -dependencyfile &quot;${basedir}/${build.dir}/.scala_dependencies&quot; @{addparams}</xsl:attribute>
+                            <xsl:attribute name="addparams">-dependencyfile &quot;${basedir}/${build.dir}/.scala_dependencies&quot; @{addparams}</xsl:attribute>
                             <!--<xsl:attribute name="includeantruntime">false</xsl:attribute>-->
                             <classpath>
                                 <path>


### PR DESCRIPTION
Scala 2.11.x has removed the -make:transitive command line option for scalac.