### PR TITLE
Allow SBT projects with ancestor folders named src

### DIFF
--- a/scala.sbt/src/main/scala/org/netbeans/modules/scala/sbt/project/SBTProjectType.scala
+++ b/scala.sbt/src/main/scala/org/netbeans/modules/scala/sbt/project/SBTProjectType.scala
@@ -2,6 +2,7 @@ package org.netbeans.modules.scala.sbt.project
 
 import java.io.IOException
 import org.netbeans.api.project.Project
+import org.netbeans.api.project.ProjectManager
 import org.netbeans.spi.project.ProjectFactory
 import org.netbeans.spi.project.ProjectState
 import org.openide.filesystems.FileObject
@@ -61,7 +62,7 @@ object SBTProjectType {
   }
 
   def isSBTProjectDir(projDir: FileObject) = {
-    !isMavenProject(projDir) && !isProjectFolder(projDir) && !isUnderSrcFolder(projDir) &&
+    !isMavenProject(projDir) && !isProjectFolder(projDir) && !isWithinOtherProject(projDir) &&
       (hasSbtProjectDefinition(projDir) || hasStdScalaSrcDir(projDir) || hasNBDescriptorFile(projDir))
   }
 
@@ -88,8 +89,16 @@ object SBTProjectType {
     projectDir.getNameExt == "project"
   }
 
-  def isUnderSrcFolder(projectDir: FileObject) = {
-    projectDir.getPath.split("/") find (_ == "src") isDefined
+  def isWithinOtherProject(projectDir: FileObject) = {
+    isProjectRecursiveParent(projectDir.getParent)
+  }
+
+  private def isProjectRecursiveParent(dir: FileObject): Boolean = Option(dir) match {
+    case None => false
+    case Some(x) => if (ProjectManager.getDefault.isProject(x))
+      true
+    else
+      isProjectRecursiveParent(x.getParent)
   }
 
   def hasStdScalaSrcDir(projectDir: FileObject): Boolean = {


### PR DESCRIPTION
Previously SBTProjectType would ignore folders with an ancestor named
"src" in the path. Instead, check if any of the ancestors is a project
using ProjectManager.isProject().