### PR TITLE
Fixed issue #152 (https://github.com/dcaoyuan/nbscala/issues/152)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
                     <!-- https://github.com/mojohaus/nbm-maven-plugin -->
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>nbm-maven-plugin</artifactId>
-                    <version>3.14</version>
+                    <version>3.14.1</version>
                     <extensions>true</extensions>
                     <configuration>
                         <brandingToken>${brandingToken}</brandingToken>

--- a/scala.debugger/pom.xml
+++ b/scala.debugger/pom.xml
@@ -32,6 +32,10 @@
         </dependency>
         <dependency>
             <groupId>org.netbeans.api</groupId>
+            <artifactId>org-netbeans-modules-java-source-base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-modules-java-sourceui</artifactId>
         </dependency>
         <dependency>
@@ -110,7 +114,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        
+
         <!-- subproject dependencies -->
         <dependency>
             <groupId>org.netbeans.modules</groupId>
@@ -128,7 +132,7 @@
             <groupId>org.netbeans.modules</groupId>
             <artifactId>org-netbeans-modules-scala-debugger-projects</artifactId>
         </dependency>
-       
+
     </dependencies>
 
     <build>
@@ -145,7 +149,7 @@
                     <author>Caoyuan Deng</author>
                     <codeNameBase>org.netbeans.modules.scala.debugger/1</codeNameBase>
                     <licenseName>CDDL-GPLV2</licenseName>
-                    <licenseFile>license.txt</licenseFile>    
+                    <licenseFile>license.txt</licenseFile>
                     <publicPackages>
                     </publicPackages>
                 </configuration>


### PR DESCRIPTION
As stated in the issue #152, I tried to do `mvn clean install` of the project and it failed with a rather cryptic error (for me at least).

When looking for causes I found [this issue](https://github.com/mojohaus/nbm-maven-plugin/issues/6) in the `nmb-maven-plugin` project repo. 

After updating version of `nbm-maven-plugin` in master `pom.xml` from `3.14` to `3.14.1`  the root problem of failing build seemed to be in missing explicit dependency on `org.netbeans.api:org-netbeans-modules-java-source-base` in the `scala.debugger` project. After I added the mentioned dependency, the project could be built successfully. 

Here's a [pastebin](http://pastebin.com/9Prcbbkj) with full `mvn clean install` output after my changes.