### PR TITLE
Fix for issue #159 Scala Find Usages results are in random order within file

### DIFF
--- a/scala.refactoring/src/main/scala/org/netbeans/modules/scala/refactoring/WhereUsedElement.scala
+++ b/scala.refactoring/src/main/scala/org/netbeans/modules/scala/refactoring/WhereUsedElement.scala
@@ -164,10 +164,13 @@ object WhereUsedElement {
 }
 
 class WhereUsedElement(bounds: PositionBounds, displayText: String, parentFile: FileObject,
-                       name: String, range: OffsetRange, icon: Icon) extends SimpleRefactoringElementImplementation {
+                       name: String, range: OffsetRange, icon: Icon) extends SimpleRefactoringElementImplementation
+      with scala.math.Ordered[WhereUsedElement] {
 
   ElementGripFactory.getDefault.put(parentFile, name, range, icon)
 
+  def compare(that: WhereUsedElement) = (this.getPosition().getBegin().getLine() - that.getPosition().getBegin().getLine())
+  
   def getLookup: Lookup = {
     val composite = ElementGripFactory.getDefault.get(parentFile, bounds.getBegin.getOffset) match {
       case null => parentFile


### PR DESCRIPTION
`WhereUsedElement` now extends Ordered, comparing line numbers
`WhereUsedQueryPlugin` sorts `foundElements` before adding to results
(language refactoring plugins must now implement results sorting. See: 
https://hg.netbeans.org/main-golden/annotate/bebcb8289952/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringPanel.java#l466  )

(Relatively trivial, but it's a start)