### PR TITLE
Fixed travisci config and updated build requirement to java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
 deploy:
   provider: releases
   api_key: "$GH_TOKEN"
-  file: "$HOME/build/$USER/nbscala/target/netbeans_site/nbscala-plugins.zip"
+  file: "$HOME/build/$TRAVIS_REPO_SLUG/target/netbeans_site/nbscala-plugins.zip"
   skip_cleanup: true
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
 deploy:
   provider: releases
   api_key: "$GH_TOKEN"
-  file: "/home/travis/build/akochnev/nbscala/target/netbeans_site/nbscala-plugins.zip"
+  file: "$HOME/build/$USER/nbscala/target/netbeans_site/nbscala-plugins.zip"
   skip_cleanup: true
   on:
     tags: true


### PR DESCRIPTION
I'm not entirely sure when the requirement for building changed to java 8 ( I have a sense that it might have been a part of NetBeans 8), but prior to this change, the build failed w/  Java 7. I updated the Readme to reflect that. 

In addition to that, I generalized the travisci config - it should be fairly easy to set up the travisci integration on the main dcaoyuan/nbscala repo so that bits are published whenever a release is tagged in github. The updated travisci config no longer has my hardcoded username, so it should generalize to anyone using this repo who want to have automated builds. 