### PR TITLE
Apache Netbeans (incubating) 9.0-vc3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
             <email>oliver.guenther [at] gg-net.de</email>
             <timezone>+2</timezone>
         </developer>
+        <developer>
+            <id>cbm64chris</id>
+            <name>Chris Luff</name>
+            <email>chris1976 [at] me.com</email>
+            <timezone>+0</timezone>
+        </developer>
     </developers>
 
     <licenses>
@@ -58,7 +64,7 @@
              we should build it using lower version NetBeans to get it to be able installed both
              on lower and higher version, unless we use un-compatible features of higher version.
         -->
-        <netbeans.version>RELEASE82</netbeans.version>
+        <netbeans.version>9.0</netbeans.version>
 
         <scala.version>2.11.3-nbscala</scala.version> <!-- use nbscala patched scala runtime @see libs.local-->
         <sbt.version>0.13.1</sbt.version>
@@ -82,6 +88,9 @@
         <scala.sbt.version>1.8.2.1</scala.sbt.version>
         <scala.sbt.project.version>1.8.2.0</scala.sbt.project.version>
         <scala.stdplatform.version>1.8.2.0</scala.stdplatform.version>
+        
+        <nb.installation>/Applications/NetBeans/NetBeans 9.0.app/Contents/Resources/NetBeans</nb.installation>
+        <nb.nbmdirectory>${basedir}/nbms</nb.nbmdirectory>
     </properties>
 
     <repositories>
@@ -131,7 +140,7 @@
                     <!-- https://github.com/mojohaus/nbm-maven-plugin -->
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>nbm-maven-plugin</artifactId>
-                    <version>3.14.1</version>
+                    <version>4.1</version>
                     <extensions>true</extensions>
                     <configuration>
                         <brandingToken>${brandingToken}</brandingToken>
@@ -151,12 +160,13 @@
                     <!-- mvn nb-repository:populate -->
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>nb-repository-plugin</artifactId>
-                    <version>1.3</version>
+                    <version>1.4-SNAPSHOT</version>
                     <extensions>true</extensions>
                     <configuration>
                         <!-- to have the goal 'nb-repository:populate' find the installation and populating the local repository with them, set it on your maven settings.xml -->
                         <netbeansInstallDirectory>${nb.installation}</netbeansInstallDirectory>
                         <netbeansNbmDirectory>${nb.nbmdirectory}</netbeansNbmDirectory>
+                        <forcedVersion>${netbeans.version}</forcedVersion>
                     </configuration>
                 </plugin>
 
@@ -189,8 +199,6 @@
                     <artifactId>maven-install-plugin</artifactId>
                     <version>2.4</version>
                 </plugin>
-
-
 
                 <!-- Scala plugin for compiling and running Scala -->
                 <plugin>
@@ -837,11 +845,6 @@
             <dependency>
                 <groupId>org.netbeans.api</groupId>
                 <artifactId>org-netbeans-modules-java-platform-ui</artifactId>
-                <version>${netbeans.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.netbeans.api</groupId>
-                <artifactId>org-jdesktop-layout</artifactId>
                 <version>${netbeans.version}</version>
             </dependency>
             <dependency>

--- a/scala.editor/pom.xml
+++ b/scala.editor/pom.xml
@@ -14,10 +14,10 @@
     <packaging>nbm</packaging>
 
     <dependencies>
-        <dependency>
+<!--        <dependency>
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-jdesktop-layout</artifactId>
-        </dependency>
+        </dependency>-->
         <dependency>
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-core-multiview</artifactId>

--- a/scala.editor/src/main/scala/org/netbeans/modules/scala/editor/options/FmtTabsIndents.scala
+++ b/scala.editor/src/main/scala/org/netbeans/modules/scala/editor/options/FmtTabsIndents.scala
@@ -23,6 +23,9 @@ import org.netbeans.api.editor.settings.SimpleValueNames
 import org.netbeans.modules.options.editor.spi.PreferencesCustomizer
 import org.openide.util.NbBundle
 
+import javax.swing.GroupLayout
+import javax.swing.LayoutStyle
+
 import org.netbeans.modules.scala.editor.options.FmtOptions._
 
 /**
@@ -95,38 +98,36 @@ class FmtTabsIndents extends javax.swing.JPanel {
 
     org.openide.awt.Mnemonics.setLocalizedText(indentHtmlCheckBox, org.openide.util.NbBundle.getMessage(classOf[FmtTabsIndents], "LBL_IndentHTML")); // NOI18N
 
-    val layout = new org.jdesktop.layout.GroupLayout(this);
+    val layout = new GroupLayout(this)
     this.setLayout(layout);
     layout.setHorizontalGroup(
-      layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-        .add(layout.createSequentialGroup()
-          .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(layout.createSequentialGroup()
-              .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                .add(indentSizeLabel)
-                .add(continuationIndentSizeLabel))
-              .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-              .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING, false)
-                .add(indentSizeField)
-                .add(continuationIndentSizeField, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 75, Short.MaxValue)))
-            .add(reformatCommentsCheckBox)
-            .add(indentHtmlCheckBox))
-          .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MaxValue)));
+      layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+        .addGroup(layout.createSequentialGroup.addGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+          .addGroup(layout.createSequentialGroup.addGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+            .addComponent(indentSizeLabel)
+            .addComponent(continuationIndentSizeLabel))
+            .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+            .addGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING, false)
+              .addComponent(indentSizeLabel)
+              .addComponent(continuationIndentSizeLabel, GroupLayout.DEFAULT_SIZE, 75, Short.MaxValue)))
+          .addComponent(reformatCommentsCheckBox)
+          .addComponent(indentHtmlCheckBox))
+          .addContainerGap(GroupLayout.DEFAULT_SIZE, Short.MaxValue)))
+
     layout.setVerticalGroup(
-      layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-        .add(layout.createSequentialGroup()
-          .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-            .add(indentSizeLabel)
-            .add(indentSizeField, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-          .add(14, 14, 14)
-          .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-            .add(continuationIndentSizeLabel)
-            .add(continuationIndentSizeField, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-          .add(18, 18, 18)
-          .add(reformatCommentsCheckBox)
-          .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-          .add(indentHtmlCheckBox)
-          .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MaxValue)));
+      layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+        .addGroup(layout.createSequentialGroup.addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+          .addComponent(indentSizeLabel)
+          .addComponent(indentSizeField, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
+          .addGap(14, 14, 14)
+          .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+            .addComponent(continuationIndentSizeLabel)
+            .addComponent(continuationIndentSizeField, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
+          .addGap(18, 18, 18)
+          .addComponent(reformatCommentsCheckBox)
+          .addPreferredGap(LayoutStyle.ComponentPlacement.UNRELATED)
+          .addComponent(indentHtmlCheckBox)
+          .addContainerGap(GroupLayout.DEFAULT_SIZE, Short.MaxValue)))
   } // </editor-fold>//GEN-END:initComponents
 
 }

--- a/scala.project/pom.xml
+++ b/scala.project/pom.xml
@@ -20,10 +20,6 @@
         </dependency>
         <dependency>
             <groupId>org.netbeans.api</groupId>
-            <artifactId>org-jdesktop-layout</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-api-java</artifactId>
         </dependency>
         <dependency>
@@ -196,7 +192,11 @@
             <groupId>org.netbeans.modules</groupId>
             <artifactId>org-netbeans-modules-scala-stdplatform</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.swinglabs</groupId>
+            <artifactId>swing-layout</artifactId>
+            <version>1.0.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/scala.project/src/main/java/org/netbeans/modules/scala/project/ui/wizards/PanelOptionsVisual.form
+++ b/scala.project/src/main/java/org/netbeans/modules/scala/project/ui/wizards/PanelOptionsVisual.form
@@ -12,6 +12,7 @@
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_generateFQN" type="java.lang.Boolean" value="true"/>
     <AuxValue name="FormSettings_generateMnemonicsCode" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_i18nAutoMode" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_layoutCodeTarget" type="java.lang.Integer" value="2"/>
@@ -23,15 +24,10 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Component id="setAsMainCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
           <Group type="102" alignment="0" attributes="0">
               <Component id="createMainCheckBox" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="mainClassTextField" pref="344" max="32767" attributes="0"/>
-          </Group>
-          <Group type="102" alignment="0" attributes="0">
-              <Component id="sharableProject" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
           </Group>
           <Group type="102" alignment="0" attributes="0">
               <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
@@ -39,6 +35,13 @@
               <Component id="librariesLocation" pref="203" max="32767" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="browseLibraries" min="-2" max="-2" attributes="0"/>
+          </Group>
+          <Group type="102" attributes="0">
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="setAsMainCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="sharableProject" alignment="0" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>

--- a/scala.project/src/main/java/org/netbeans/modules/scala/project/ui/wizards/PanelOptionsVisual.java
+++ b/scala.project/src/main/java/org/netbeans/modules/scala/project/ui/wizards/PanelOptionsVisual.java
@@ -61,6 +61,9 @@ import org.openide.filesystems.FileUtil;
 import org.openide.util.NbBundle;
 import org.openide.util.Utilities;
 
+import javax.swing.GroupLayout;
+import javax.swing.LayoutStyle;
+
 /**
  * @author  phrebejk
  */
@@ -205,49 +208,48 @@ public class PanelOptionsVisual extends SettingsPanel implements ActionListener,
         org.openide.awt.Mnemonics.setLocalizedText(setAsMainCheckBox, org.openide.util.NbBundle.getBundle(PanelOptionsVisual.class).getString("LBL_setAsMainCheckBox")); // NOI18N
         setAsMainCheckBox.setMargin(new java.awt.Insets(0, 0, 0, 0));
 
-        org.jdesktop.layout.GroupLayout layout = new org.jdesktop.layout.GroupLayout(this);
+        GroupLayout layout = new GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
-            layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(layout.createSequentialGroup()
-                .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                    .add(cbSharable)
-                    .add(layout.createSequentialGroup()
-                        .add(19, 19, 19)
-                        .add(lblLibFolder)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                            .add(lblHint, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 243, Short.MAX_VALUE)
-                            .add(txtLibFolder, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 243, Short.MAX_VALUE))))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(btnLibFolder))
-            .add(layout.createSequentialGroup()
-                .add(setAsMainCheckBox)
-                .addContainerGap())
-            .add(layout.createSequentialGroup()
-                .add(createMainCheckBox)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(mainClassTextField, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 319, Short.MAX_VALUE))
-        );
+            layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                .addGroup(layout.createSequentialGroup()
+                    .addGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                        .addComponent(cbSharable)
+                        .addGroup(layout.createSequentialGroup()
+                            .addGap(19,19,19)
+                            .addComponent(lblLibFolder)
+                            .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)    
+                            .addGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                                .addComponent(lblHint, GroupLayout.PREFERRED_SIZE, 243, Short.MAX_VALUE)
+                                .addComponent(txtLibFolder, GroupLayout.DEFAULT_SIZE, 243, Short.MAX_VALUE))))
+                    .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                    .addComponent(btnLibFolder))
+                .addGroup(layout.createSequentialGroup()
+                    .addComponent(setAsMainCheckBox)
+                    .addContainerGap())
+                .addGroup(layout.createSequentialGroup()
+                    .addComponent(createMainCheckBox)
+                    .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                    .addComponent(mainClassTextField, GroupLayout.DEFAULT_SIZE, 319, Short.MAX_VALUE)));
+
         layout.setVerticalGroup(
-            layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(layout.createSequentialGroup()
-                .add(cbSharable)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(btnLibFolder)
-                    .add(txtLibFolder, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                    .add(lblLibFolder))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(lblHint)
-                .add(30, 30, 30)
-                .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(createMainCheckBox)
-                    .add(mainClassTextField, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(setAsMainCheckBox)
-                .addContainerGap(50, Short.MAX_VALUE))
-        );
+            layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+            .addGroup(layout.createSequentialGroup()
+                .addComponent(cbSharable)
+                .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                    .addComponent(btnLibFolder)
+                    .addComponent(txtLibFolder, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
+                    .addComponent(lblLibFolder))
+                .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(lblHint)
+                .addGap(30, 30, 30)
+                .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                    .addComponent(createMainCheckBox)
+                    .addComponent(mainClassTextField, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(setAsMainCheckBox)
+                .addContainerGap(50, Short.MAX_VALUE)));
 
         cbSharable.getAccessibleContext().setAccessibleDescription(org.openide.util.NbBundle.getMessage(PanelOptionsVisual.class, "ACSD_sharableProject")); // NOI18N
         txtLibFolder.getAccessibleContext().setAccessibleDescription(org.openide.util.NbBundle.getMessage(PanelOptionsVisual.class, "ACSD_LibrariesLocation")); // NOI18N

--- a/scala.refactoring/pom.xml
+++ b/scala.refactoring/pom.xml
@@ -16,10 +16,6 @@
     <dependencies>
         <dependency>
             <groupId>org.netbeans.api</groupId>
-            <artifactId>org-jdesktop-layout</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-api-java-classpath</artifactId>
         </dependency>
         <dependency>

--- a/scala.refactoring/src/main/scala/org/netbeans/modules/scala/refactoring/WhereUsedElement.scala
+++ b/scala.refactoring/src/main/scala/org/netbeans/modules/scala/refactoring/WhereUsedElement.scala
@@ -165,12 +165,12 @@ object WhereUsedElement {
 
 class WhereUsedElement(bounds: PositionBounds, displayText: String, parentFile: FileObject,
                        name: String, range: OffsetRange, icon: Icon) extends SimpleRefactoringElementImplementation
-      with scala.math.Ordered[WhereUsedElement] {
+    with scala.math.Ordered[WhereUsedElement] {
 
   ElementGripFactory.getDefault.put(parentFile, name, range, icon)
 
   def compare(that: WhereUsedElement) = (this.getPosition().getBegin().getLine() - that.getPosition().getBegin().getLine())
-  
+
   def getLookup: Lookup = {
     val composite = ElementGripFactory.getDefault.get(parentFile, bounds.getBegin.getOffset) match {
       case null => parentFile

--- a/scala.refactoring/src/main/scala/org/netbeans/modules/scala/refactoring/WhereUsedQueryPlugin.scala
+++ b/scala.refactoring/src/main/scala/org/netbeans/modules/scala/refactoring/WhereUsedQueryPlugin.scala
@@ -384,7 +384,7 @@ class WhereUsedQueryPlugin(refactoring: WhereUsedQuery) extends ScalaRefactoring
       }
 
       elements.addAll(refactoring, foundElements.sortWith(_.compare(_) < 0))
-      
+
       Nil
     }
 

--- a/scala.refactoring/src/main/scala/org/netbeans/modules/scala/refactoring/ui/WhereUsedPanel.scala
+++ b/scala.refactoring/src/main/scala/org/netbeans/modules/scala/refactoring/ui/WhereUsedPanel.scala
@@ -70,6 +70,9 @@ import org.netbeans.modules.scala.core.ast.ScalaItems
 import org.netbeans.modules.scala.refactoring.RefactoringModule
 import scala.reflect.internal.Flags
 
+import javax.swing.GroupLayout
+import javax.swing.LayoutStyle
+
 /**
  * @author  Jan Becicka
  */
@@ -438,20 +441,20 @@ class WhereUsedPanel(name: String, element: ScalaItems#ScalaItem, parent: Change
       }
     });
 
-    val scopePanelLayout = new org.jdesktop.layout.GroupLayout(scopePanel);
+    val scopePanelLayout = new GroupLayout(scopePanel);
     scopePanel.setLayout(scopePanelLayout);
     scopePanelLayout.setHorizontalGroup(
-      scopePanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-        .add(scopePanelLayout.createSequentialGroup()
-          .addContainerGap()
-          .add(scopeLabel)
-          .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-          .add(scope, 0, 266, Short.MaxValue)
-          .addContainerGap()));
+      scopePanelLayout.createParallelGroup(GroupLayout.Alignment.LEADING)
+        .addGroup(scopePanelLayout.createSequentialGroup
+          .addContainerGap
+          .addComponent(scopeLabel)
+          .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+          .addComponent(scope, 0, 266, Short.MaxValue)
+          .addContainerGap));
     scopePanelLayout.setVerticalGroup(
-      scopePanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-        .add(scopeLabel)
-        .add(scope, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 20, Short.MaxValue));
+      scopePanelLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+        .addComponent(scopeLabel)
+        .addComponent(scope, GroupLayout.PREFERRED_SIZE, 20, Short.MaxValue));
 
     scope.getAccessibleContext().setAccessibleDescription("N/A");
 


### PR DESCRIPTION
This PR uplifts the nbscala plugin to Apache Netbeans (incubating) 9.0-vc3. The maven artifacts are not available as yet so you have to build them manually from the Netbeans source ([instructions](https://dzone.com/articles/apache-netbeans-and-scala)).

![nbscala](https://user-images.githubusercontent.com/20171342/42641374-5061a4fc-85ec-11e8-80c8-c74b6c0d506e.png)
